### PR TITLE
Propose a grouping of functions

### DIFF
--- a/R/EBImage.R
+++ b/R/EBImage.R
@@ -1,6 +1,6 @@
 #' Convert to EBImage
 #'
-#' Convert a Magck image to [EBImage](https://bioconductor.org/packages/release/bioc/html/EBImage.html)
+#' Convert a Magick image to [EBImage](https://bioconductor.org/packages/release/bioc/html/EBImage.html)
 #' class. Note that EBImage only supports multi-frame images in greyscale.
 #'
 #' @export

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,3 +18,49 @@ navbar:
   right:
     - icon: fa-github
       href: https://github.com/ropensci/magick
+
+reference:
+- title: Example images
+  contents:
+  - '`wizard`'
+- title: Image Editing
+  contents:
+  - '`editing`'
+  - '`transform`'
+  - '`fx`'
+  - '`morphology`'
+  - '`effects`'
+  - '`color`'
+  - '`painting`'
+  - '`as_EBImage`'
+  - '`image_ggplot`'
+- title: Magick Graphics Device
+  contents:
+  - '`device`'
+- title: Image Attributes
+  contents:
+  - '`attributes`'
+- title: Image Composite
+  contents:
+  - '`composite`'
+- title: Image Frames and Animation
+  contents:
+  - '`animation`'
+  - '`video`'
+- title: Geometry helpers
+  contents:
+  - '`geometry`'
+- title: Image Processing
+  desc: ~
+  contents:
+  - '`analysis`'
+  - '`edges`'
+  - '`ocr`'
+  - '`segmentation`'
+  - '`thresholding`'
+- title: Software options
+  contents:
+  - '`options`'
+  - '`coder_info`'
+  - '`autoviewer`'
+


### PR DESCRIPTION
The goal is to not only have "All functions" in the reference TOC. I used `pkgdown::template_reference()` and then copy-pasted things around, using `pkgdown::build_reference_index()` to get a preview.

This is probably very imperfect, in particular the section called "Image Processing".