### PR TITLE
Fixing images in inline chunks

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -113,14 +113,32 @@ rep_magick_image <- function(x, times){
     invisible()
 }
 
+
+
 # This is registered as an S3 method in .onLoad()
-"knit_print.magick-image" <- function(x, ...){
+"knit_print.magick-image" <- function(x, ..., inline = FALSE){
   if(!length(x))
     return(invisible())
-  plot_counter <- utils::getFromNamespace('plot_counter', 'knitr')
+
   in_base_dir <- utils::getFromNamespace('in_base_dir', 'knitr')
   ext <- ifelse(all(tolower(image_info(x)$format) == "gif"), "gif", "png")
-  tmp <- knitr::fig_path(ext, number = plot_counter())
+
+  if (inline) {
+    fig_path <- knitr::opts_chunk$get("fig.path")
+    n <- knitr::opts_chunk$get("fig.inline.cur")
+    if (is.null(n)) {
+      n <- 1
+    }
+    knitr::opts_chunk$set("fig.inline.cur" = n+1)
+
+    tmp <- file.path(
+      fig_path,
+      paste0("inline-fig-", n, ".", ext)
+    )
+  } else {
+    plot_counter <- utils::getFromNamespace('plot_counter', 'knitr')
+    tmp <- knitr::fig_path(ext, number = plot_counter())
+  }
 
   # save relative to 'base' directory, see discussion in #110
   in_base_dir({


### PR DESCRIPTION
As discussed in #310 this is an attempted fix for the issue. It works by distinguishing between the inline and regular chunk cases.

The inline solution is a bit hacky as the inline chunks are tracked by adding a `fig.inline.cur` option to the global chunk options which is then incremented for each inline image.

One additional issue is the possible collision between "inline-fig-*.ext" naming convention, this seems unlikely but maybe it would be better to create a separate inline folder within fig.path.
